### PR TITLE
Test out method behavior.

### DIFF
--- a/disk.c
+++ b/disk.c
@@ -49,6 +49,8 @@ struct disk * disk_open( const char *diskname, int nblocks )
 
 void disk_write( struct disk *d, int block, const char *data )
 {
+    printf("disk: writing to block %d", block);
+
 	if(block<0 || block>=d->nblocks) {
 		fprintf(stderr,"disk_write: invalid block #%d\n",block);
 		abort();
@@ -61,8 +63,10 @@ void disk_write( struct disk *d, int block, const char *data )
 	}
 }
 
-void disk_read( struct disk *d, int block, char *data )
-{
+void disk_read( struct disk *d, int block, char *data ) {
+
+    printf("disk: reading from block %d", block);
+
 	if(block<0 || block>=d->nblocks) {
 		fprintf(stderr,"disk_read: invalid block #%d\n",block);
 		abort();

--- a/main.c
+++ b/main.c
@@ -15,14 +15,13 @@ how to use the page table and disk interfaces.
 #include <string.h>
 #include <errno.h>
 
-void page_fault_handler( struct page_table *pt, int page )
-{
-	printf("page fault on page #%d\n",page);
-	exit(1);
+void page_fault_handler( struct page_table *pageTable, int page ) {
+	printf("page fault: %d\n", page);
+	int frame = rand() % pageTable->nframes;
+	page_table_set_entry(pageTable, page, frame, PROT_READ|PROT_WRITE);
 }
 
-int main( int argc, char *argv[] )
-{
+int main( int argc, char *argv[] ) {
 	if(argc!=5) {
 		printf("use: virtmem <npages> <nframes> <rand|fifo|custom> <sort|scan|focus>\n");
 		return 1;
@@ -60,7 +59,6 @@ int main( int argc, char *argv[] )
 
 	} else {
 		fprintf(stderr,"unknown program: %s\n",argv[3]);
-
 	}
 
 	page_table_delete(pt);

--- a/main.c
+++ b/main.c
@@ -15,9 +15,13 @@ how to use the page table and disk interfaces.
 #include <string.h>
 #include <errno.h>
 
+
+// My understanding is that, when a page fault occurs, we need to evict data from a page.
+// To do that, we must preserve memory writes by writing the frame where the fault occurs
+// to the disk. Then, the next time the frame is loaded, the data will be preserved.
 void page_fault_handler( struct page_table *pageTable, int page ) {
-	printf("page fault: %d\n", page);
 	int frame = rand() % pageTable->nframes;
+	printf("page fault: setting page %d to frame %d\n", page, frame);
 	page_table_set_entry(pageTable, page, frame, PROT_READ|PROT_WRITE);
 }
 
@@ -49,7 +53,7 @@ int main( int argc, char *argv[] ) {
 	char *physmem = page_table_get_physmem(pt);
 
 	if(!strcmp(program,"sort")) {
-		sort_program(virtmem,npages*PAGE_SIZE);
+		sort_program(virtmem, npages * 5);
 
 	} else if(!strcmp(program,"scan")) {
 		scan_program(virtmem,npages*PAGE_SIZE);

--- a/program.c
+++ b/program.c
@@ -60,18 +60,31 @@ void sort_program( char *data, int length )
 		data[i] = rand();
 	}
 
-	qsort(data,length,1,compare_bytes);
-
+	printf("before sorting:\n\n");
 	for(i=0;i<length;i++) {
+		printf("%d ", data[i]);
 		total += data[i];
 	}
+	printf("\n\n");
 
-	printf("sort result is %d\n",total);
+	printf("sum is %d\n",total);
+	total = 0;
 
+	qsort(data,length,1,compare_bytes);
+
+	printf("after sorting:\n\n");
+	for(i=0;i<length;i++) {
+		printf("%d ", data[i]);
+		total += data[i];
+	}
+	printf("\n\n");
+
+	printf("sum is %d\n",total);
 }
 
 void scan_program( char *cdata, int length )
 {
+	printf("length: %d\n", length);
 	unsigned i, j;
 	unsigned char *data = (unsigned char*) cdata;
 	unsigned total = 0;


### PR DESCRIPTION
The test here shows that the page fault handler isn't called when there are only a few pages. In that case, we shouldn't need to do any of the disk replacement stuff.

I think discussing how the base code works will help us understand the project. After all, all the sample programs do is read and write to a char* - how could that call our signal handler?
As it turns out, `page_table.c` declares an `internal_fault_handler`:

https://github.com/elliott-beach/project2_base/blob/3e794e9af9b0464fa231ab5171e331025b04f567/page_table.c#L24-L46

This calls the fault handler whenever there are more pages than we can possibly use. There is an `mmap` call in page_table which allocates the physical memory (frames are stored on physical memory).

For the disk, normally when a page fault occurs the page will simply allocate the next available frame in physical memory. If all frames are allocated, the contents of a page will be persisted to disk, and the page's frame will be re-assigned to the new page. The page that previously had that frame should be marked as void.

In terms of how many times the replacement algorithm should be expected to execute, by default, the `sort_program` expects an array `npages*PAGE_SIZE` ints. Because a page has `npages*PAGE_SIZE` memory, that means the array is four times the size of what can be held in memory by the page table (int=4 bytes).

Also, we already did this project in CSCI 2021/4061, I'm calling the curriculum police and sending Weissman to curriculum prison.